### PR TITLE
Specify auto_adjust in Yahoo Finance download

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -99,12 +99,19 @@ class TraderBot:
         self.account = PaperAccount(config.starting_balance, config.max_exposure)
 
     def fetch_candles(self) -> pd.DataFrame:
-        """Fetch recent OHLCV data from Yahoo Finance."""
+        """Fetch recent OHLCV data from Yahoo Finance.
+
+        Data is downloaded with ``auto_adjust`` set to ``False`` to preserve the
+        raw price data returned by Yahoo Finance. Set this argument to ``True``
+        if adjusted prices (accounting for splits/dividends) are desired in the
+        future.
+        """
         df = yf.download(
             tickers=self.config.symbol,
             period="7d",
             interval=self.config.timeframe,
             progress=False,
+            auto_adjust=False,  # preserve raw prices for trading
         )
         df = df.rename(
             columns={


### PR DESCRIPTION
## Summary
- explicitly disable price adjustments when downloading data from Yahoo Finance
- document that auto_adjust preserves raw prices and can be enabled if adjusted data is needed

## Testing
- `python -m py_compile src/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689d95705dd0832cba3c7866de811bc2