### PR TITLE
Add stop-loss and risk controls to trading bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository explores building an autonomous cryptocurrency trading bot.
 
 ## Overview
 
-The example bot in `src/bot.py` fetches price data from [Yahoo Finance](https://finance.yahoo.com/) using the [`yfinance`](https://github.com/ranaroussi/yfinance) library and demonstrates a simple moving average crossover strategy. A built-in paper trading account simulates trades with a starting balance of $1000 and a maximum exposure of 75% of the account. Each trade is logged to `trade_log.csv` with profit or loss and the duration the position was held.
+The example bot in `src/bot.py` fetches price data from [Yahoo Finance](https://finance.yahoo.com/) using the [`yfinance`](https://github.com/ranaroussi/yfinance) library and demonstrates a simple moving average crossover strategy. A built-in paper trading account simulates trades with a starting balance of $1000 and a maximum exposure of 75% of the account. Each trade is logged to `trade_log.csv` with profit or loss and the duration the position was held.  Stop‑loss and take‑profit levels are applied to every position, and the bot halts if account drawdown exceeds a configurable threshold.
 
 
 ## Disclaimer
@@ -24,5 +24,5 @@ pip install -r requirements.txt
 - On Windows, `start_bot.bat` installs dependencies and launches the bot.
 - Use `update.bat` to pull the latest repository changes.
 
-Configuration such as trading pair, starting balance, and exposure limits can be adjusted in the `Config` dataclass inside `src/bot.py`.
+Configuration such as trading pair, stop‑loss/take‑profit percentages, drawdown limit, starting balance, and exposure limits can be adjusted in the `Config` dataclass inside `src/bot.py`.
 


### PR DESCRIPTION
## Summary
- add stop-loss and take-profit handling for open positions
- implement drawdown-based risk control and performance metrics
- document new configuration options

## Testing
- `python -m py_compile src/bot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d9f0217b0832cb08d2a9041b29a6b