### PR TITLE
Add dynamic symbol fetching and multi-symbol trading loop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-
 pandas
 yfinance
 ccxt
-
+requests


### PR DESCRIPTION
## Summary
- add requests dependency
- implement SymbolFetcher thread to fetch top-volume symbols from BinanceUS
- trade across fetched symbols in main bot loop with per-cycle pauses

## Testing
- `python -m py_compile src/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689da93d97b8832c8be4c2be3e21e757