### PR TITLE
Allow configuring CCXT exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ pip install -r requirements.txt
 - On Windows, `start_bot.bat` installs dependencies and launches the bot.
 - Use `update.bat` to pull the latest repository changes.
 
-Configuration such as trading pair, stop‑loss/take‑profit percentages, drawdown limit, starting balance, and exposure limits can be adjusted in the `Config` dataclass inside `src/bot.py`.
+Configuration such as trading pair, exchange (default `binanceus`), stop‑loss/take‑profit percentages, drawdown limit, starting balance, and exposure limits can be adjusted in the `Config` dataclass inside `src/bot.py`. The exchange value determines which CCXT exchange provides fallback price data.
 


### PR DESCRIPTION
## Summary
- Allow selecting CCXT exchange for candle fallback via new `Config.exchange` parameter
- Update `fetch_candles_ccxt` to use dynamic CCXT exchange selection
- Document exchange configuration in README

## Testing
- `python -m py_compile src/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689dae6bdf64832c92ee0c57ac9b5048