### PR TITLE
Switch to CCXT for data fetching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pandas
-yfinance
 ccxt
 requests


### PR DESCRIPTION
## Summary
- validate BinanceUS symbols via `ccxt.binanceus().fetch_ticker` instead of `yfinance`
- fetch candles directly with CCXT, removing the Yahoo Finance fallback
- drop `yfinance` from imports and project dependencies

## Testing
- `python -m py_compile src/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689db22a4a0c832ca8b189e406ddb930