### PR TITLE
Fix USD pair mapping for CCXT fetch

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -196,7 +196,7 @@ class TraderBot:
         exchange = exchange_class()
         symbol = self.config.symbol.replace("-", "/")
         if symbol.endswith("USD"):
-            symbol = symbol[:-3] + "/USDT"
+            symbol = symbol[:-3] + "USDT"
         data = exchange.fetch_ohlcv(
             symbol=symbol, timeframe=self.config.timeframe, limit=100
         )


### PR DESCRIPTION
## Summary
- correct binance USD pair conversion when using CCXT

## Testing
- `python -m py_compile src/bot.py`
- `python - <<'PY'
import sys
sys.path.append('src')
from bot import Config, TraderBot
bot = TraderBot(Config())
print(bot.fetch_candles().head())
PY` *(fails: binanceus GET https://api.binance.us/api/v3/exchangeInfo)*

------
https://chatgpt.com/codex/tasks/task_e_689db552e248832cba72fd4b834288bb