### PR TITLE
Expose EMA spans and timeframe in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ pip install -r requirements.txt
 
 Configuration such as trading pair, exchange (default `binanceus`), stop‑loss/take‑profit percentages, drawdown limit, starting balance, and exposure limits can be adjusted in the `Config` dataclass inside `src/bot.py`. The exchange value determines which CCXT exchange provides price data.
 
+To control how often the strategy trades, adjust the `timeframe` along with the `ema_fast_span` and `ema_slow_span` settings in `Config`. Shorter timeframes like `"1m"` or `"5m"` provide more frequent price updates, while smaller EMA spans make crossovers more responsive. These tweaks are useful to trigger trades during brief test runs. For example:
+
+```python
+Config(timeframe="1m", ema_fast_span=5, ema_slow_span=15)
+```
+
+Use longer spans or higher timeframes for slower, more deliberate trading.
+

--- a/src/bot.py
+++ b/src/bot.py
@@ -23,7 +23,7 @@ logging.basicConfig(level=logging.INFO)
 class Config:
 
     symbol: str = "BTC-USD"
-    timeframe: str = "1h"
+    timeframe: str = "1m"
     exchange: str = "binanceus"
     stake: float = 0.001  # trade size in asset units
     starting_balance: float = 1000.0
@@ -31,6 +31,8 @@ class Config:
     stop_loss_pct: float = 0.02  # 2% stop loss
     take_profit_pct: float = 0.04  # 4% take profit target
     max_drawdown_pct: float = 0.2  # stop trading if drawdown exceeds 20%
+    ema_fast_span: int = 12  # fast EMA span for crossover
+    ema_slow_span: int = 26  # slow EMA span for crossover
 
 
 
@@ -216,8 +218,8 @@ class TraderBot:
 
     def generate_signal(self, df: pd.DataFrame) -> Optional[str]:
         """Generate a simple moving average crossover signal."""
-        df["ema_fast"] = df["close"].ewm(span=12).mean()
-        df["ema_slow"] = df["close"].ewm(span=26).mean()
+        df["ema_fast"] = df["close"].ewm(span=self.config.ema_fast_span).mean()
+        df["ema_slow"] = df["close"].ewm(span=self.config.ema_slow_span).mean()
         if (
             df["ema_fast"].iloc[-1] > df["ema_slow"].iloc[-1]
             and df["ema_fast"].iloc[-2] <= df["ema_slow"].iloc[-2]


### PR DESCRIPTION
## Summary
- Allow configuring fast and slow EMA spans through `Config`
- Default to one-minute candles and use configurable EMA spans in crossover logic
- Document how timeframe and EMA spans influence trade frequency

## Testing
- `python -m py_compile src/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689e6f2b4298832cb4d9ced860615c80