### PR TITLE
Handle missing trade symbols in logging and execution

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -104,6 +104,11 @@ class PaperAccount:
         )
 
     def _log_to_file(self, entry: Dict) -> None:
+        symbol = entry.get("symbol")
+        if not symbol:
+            logging.warning("Skipping log entry without symbol: %s", entry)
+            return
+
         path = "trade_log.csv"
         file_exists = os.path.isfile(path)
         with open(path, "a", newline="") as f:
@@ -330,6 +335,9 @@ class TraderBot:
             symbols = self.symbol_fetcher.symbols or [self.config.symbol]
             paused = False
             for symbol in symbols:
+                if not symbol:
+                    logging.warning("Encountered empty symbol; skipping trade execution")
+                    continue
                 self.config.symbol = symbol
                 df = self.fetch_candles()
                 if df.empty:

--- a/tests/test_trade_log.py
+++ b/tests/test_trade_log.py
@@ -1,0 +1,33 @@
+import csv
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Add src directory to path for importing bot module
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from bot import Config, PaperAccount
+
+
+def test_trade_log_contains_symbol(tmp_path):
+    symbol = "TEST-USD"
+    config = Config()
+    account = PaperAccount(balance=1000.0, max_exposure=1.0, config=config)
+
+    # operate within temporary directory
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        timestamp = pd.Timestamp("2024-01-01")
+        assert account.buy(
+            price=100.0, amount=1.0, timestamp=timestamp, symbol=symbol
+        )
+
+        with open("trade_log.csv", newline="") as f:
+            rows = list(csv.DictReader(f))
+    finally:
+        os.chdir(old_cwd)
+
+    assert rows and rows[0]["symbol"] == symbol


### PR DESCRIPTION
## Summary
- warn and skip logging entries without a trade symbol
- ignore empty symbols when evaluating trades
- test that CSV log records the correct trade symbol

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f8b461a00832c80652f74f8734b00