### PR TITLE
Skip unprofitable symbols with per-symbol PnL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ pip install -r requirements.txt
 
 Configuration such as trading pair, exchange (default `binanceus`), stop‑loss/take‑profit percentages, drawdown limit, starting balance, and exposure limits can be adjusted in the `Config` dataclass inside `src/bot.py`. The exchange value determines which CCXT exchange provides price data.
 
+The bot tracks profit and loss by symbol. Use `pnl_window` to set the number of recent closed trades to evaluate and `min_profit_threshold` to require a minimum cumulative profit before continuing to trade a symbol. Symbols whose PnL over the configured window falls below the threshold are skipped.
+
 To control how often the strategy trades, adjust the `timeframe` along with the `ema_fast_span` and `ema_slow_span` settings in `Config`. Shorter timeframes like `"1m"` or `"5m"` provide more frequent price updates, while smaller EMA spans make crossovers more responsive. These tweaks are useful to trigger trades during brief test runs. For example:
 
 ```python

--- a/tests/test_symbol_pnl.py
+++ b/tests/test_symbol_pnl.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+# Add src directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from bot import Config, PaperAccount
+
+
+def test_pnl_by_symbol_window():
+    config = Config()
+    account = PaperAccount(balance=1000.0, max_exposure=1.0, config=config)
+    ts = pd.Timestamp("2024-01-01")
+
+    # first trade: profit 10
+    account.buy(price=100.0, amount=1.0, timestamp=ts, symbol="AAA-USD")
+    account.sell(price=110.0, timestamp=ts, symbol="AAA-USD")
+
+    # second trade: loss 10
+    account.buy(price=100.0, amount=1.0, timestamp=ts, symbol="AAA-USD")
+    account.sell(price=90.0, timestamp=ts, symbol="AAA-USD")
+
+    pnl_all = account.pnl_by_symbol().get("AAA-USD")
+    pnl_last = account.pnl_by_symbol(window=1).get("AAA-USD")
+
+    assert pnl_all == 0.0
+    assert pnl_last == -10.0


### PR DESCRIPTION
## Summary
- track cumulative PnL per symbol and display it in performance logs
- allow configuration of a PnL window and minimum profit threshold
- skip trading symbols whose recent PnL falls below the threshold
- document new configuration options and add a unit test for PnL tracking

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8f1956f8832c83e39901f5299b37