### PR TITLE
Ensure git user identity is set before uploading trade log

### DIFF
--- a/upload_trade_log.bat
+++ b/upload_trade_log.bat
@@ -1,6 +1,8 @@
 @echo off
 title MaxTraderAI
 echo Uploading trade log...
+git config user.name "B A"
+git config user.email "b.a@idont.com"
 git add trade_log.csv
 git commit -m "Upload trade log" || echo No changes to commit.
 git push


### PR DESCRIPTION
## Summary
- configure local git user name and email in `upload_trade_log.bat` so the script commits successfully
- revert unintended trade log changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f98e54a68832c8b4af62d6a4a7201