### PR TITLE
Add RSI filter to trading signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Configuration such as trading pair, exchange (default `binanceus`), stop‑loss/
 
 The bot tracks profit and loss by symbol. Use `pnl_window` to set the number of recent closed trades to evaluate and `min_profit_threshold` to require a minimum cumulative profit before continuing to trade a symbol. Symbols whose PnL over the configured window falls below the threshold are skipped.
 
+The strategy also calculates a 14-period Relative Strength Index (RSI) and only allows a trade when this value is above `rsi_buy_threshold` (default 55) for buys or below `rsi_sell_threshold` (default 45) for sells. The RSI period and thresholds are configurable via `rsi_period`, `rsi_buy_threshold`, and `rsi_sell_threshold` in `Config`.
+
 To control how often the strategy trades, adjust the `timeframe` along with the `ema_fast_span` and `ema_slow_span` settings in `Config`. Shorter timeframes like `"1m"` or `"5m"` provide more frequent price updates, while smaller EMA spans make crossovers more responsive. These tweaks are useful to trigger trades during brief test runs. For example:
 
 ```python

--- a/tests/test_rsi_signal.py
+++ b/tests/test_rsi_signal.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Add src directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from bot import Config, TraderBot, SymbolFetcher
+
+
+def make_df(closes):
+    timestamps = pd.date_range("2024-01-01", periods=len(closes), freq="min")
+    return pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": closes,
+            "high": closes,
+            "low": closes,
+            "close": closes,
+            "volume": [0] * len(closes),
+        }
+    )
+
+
+def test_rsi_threshold(monkeypatch):
+    # prevent background thread/network activity
+    monkeypatch.setattr(SymbolFetcher, "start", lambda self: None)
+    monkeypatch.setattr(SymbolFetcher, "wait_until_ready", lambda self, timeout=None: None)
+
+    df_buy = make_df([100] * 50 + [110])
+    df_sell = make_df([100] * 50 + [90])
+
+    bot_block_buy = TraderBot(Config(symbol="T-USD", rsi_buy_threshold=100))
+    assert bot_block_buy.generate_signal(df_buy) is None
+
+    bot_allow_buy = TraderBot(Config(symbol="T-USD", rsi_buy_threshold=50))
+    assert bot_allow_buy.generate_signal(df_buy) == "buy"
+
+    bot_block_sell = TraderBot(Config(symbol="T-USD", rsi_sell_threshold=-1))
+    assert bot_block_sell.generate_signal(df_sell) is None
+
+    bot_allow_sell = TraderBot(Config(symbol="T-USD", rsi_sell_threshold=50))
+    assert bot_allow_sell.generate_signal(df_sell) == "sell"


### PR DESCRIPTION
## Summary
- compute RSI in `generate_signal` and gate EMA crossover trades with configurable thresholds
- expose `rsi_period`, `rsi_buy_threshold`, and `rsi_sell_threshold` in `Config`
- document RSI configuration and add tests for RSI-based trade filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a433ba2888832c9d055527b2a1128f