### PR TITLE
Raise error when symbol missing in trade logs

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -143,8 +143,7 @@ class PaperAccount:
     def _log_to_file(self, entry: Dict) -> None:
         symbol = entry.get("symbol")
         if not symbol:
-            logging.warning("Skipping log entry without symbol: %s", entry)
-            return
+            raise ValueError(f"Cannot log trade without symbol: {entry}")
 
         path = "trade_log.csv"
         file_exists = os.path.isfile(path)
@@ -175,6 +174,8 @@ class PaperAccount:
         take_profit: Optional[float] = None,
         trailing_stop_pct: Optional[float] = None,
     ) -> bool:
+        if not symbol:
+            raise ValueError("Symbol must be provided for buy")
         cost = price * amount
         logging.info(
             "Computed buy amount %s for %s at price %.2f (cost %.2f)",
@@ -225,6 +226,8 @@ class PaperAccount:
         fee_pct: float = 0.0,
         trailing_stop: Optional[float] = None,
     ) -> bool:
+        if not symbol:
+            raise ValueError("Symbol must be provided for sell")
         pos = self.positions.get(symbol)
         if not pos or pos.get("symbol") != symbol:
             logging.warning(

--- a/tests/test_log_requires_symbol.py
+++ b/tests/test_log_requires_symbol.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from bot import Config, PaperAccount
+
+
+def test_log_entry_requires_symbol(tmp_path):
+    config = Config()
+    account = PaperAccount(balance=1000.0, max_exposure=1.0, config=config)
+
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        entry = {
+            "timestamp": pd.Timestamp("2024-01-01").isoformat(),
+            "symbol": "",
+            "side": "buy",
+            "price": 100.0,
+            "amount": 1.0,
+            "profit": "",
+            "duration": "",
+        }
+        with pytest.raises(ValueError):
+            account._log_to_file(entry)
+        assert not os.path.exists("trade_log.csv")
+        with pytest.raises(ValueError):
+            account.buy(price=100.0, amount=1.0, timestamp=pd.Timestamp("2024-01-01"), symbol="")
+        assert account.log == []
+    finally:
+        os.chdir(old_cwd)


### PR DESCRIPTION
## Summary
- Prevent trade logs without symbols by raising a ValueError in `PaperAccount._log_to_file`
- Enforce non-empty symbols in `buy` and `sell`
- Test that trades without symbols are rejected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9234e7ec832c938e4ddd027dda44