### PR TITLE
Use ATR-based stop-loss and take-profit

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -31,6 +31,7 @@ class Config:
     max_exposure: float = 0.75  # fraction of account allowed in a single trade
     stop_loss_pct: float = 0.02  # 2% stop loss
     take_profit_pct: float = 0.04  # 4% take profit target
+    atr_multiplier: float = 1.0  # ATR multiple for stop-loss and take-profit
     max_drawdown_pct: float = 0.2  # stop trading if drawdown exceeds 20%
     ema_fast_span: int = 12  # fast EMA span for crossover
     ema_slow_span: int = 26  # slow EMA span for crossover
@@ -443,8 +444,29 @@ class TraderBot:
         """Execute a paper trade through the PaperAccount."""
         costs = self.config.fee_pct * 2 + self.config.spread_pct
         if side == "buy":
+            atr = None
+            if self.config.atr_multiplier > 0:
+                df = self.fetch_candles(symbol)
+                if not df.empty:
+                    high_low = df["high"] - df["low"]
+                    high_close = (df["high"] - df["close"].shift()).abs()
+                    low_close = (df["low"] - df["close"].shift()).abs()
+                    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
+                    atr = (
+                        tr.rolling(window=self.config.rsi_period, min_periods=1)
+                        .mean()
+                        .iloc[-1]
+                    )
             if symbol not in self.account.positions:
-                edge = self.config.take_profit_pct - costs
+                if atr is not None and atr > 0:
+                    target_pct = (atr * self.config.atr_multiplier) / price
+                    edge = target_pct - costs
+                    stop = price - atr * self.config.atr_multiplier
+                    target = price + atr * self.config.atr_multiplier
+                else:
+                    edge = self.config.take_profit_pct - costs
+                    stop = price * (1 - self.config.stop_loss_pct)
+                    target = price * (1 + self.config.take_profit_pct)
                 if edge < self.config.min_edge_pct:
                     logging.info(
                         "Buy skipped: edge %.4f below minimum %.4f",
@@ -469,8 +491,6 @@ class TraderBot:
                 if amount <= 0:
                     logging.warning("Buy skipped: non-positive amount %s", amount)
                     return
-                stop = price * (1 - self.config.stop_loss_pct)
-                target = price * (1 + self.config.take_profit_pct)
                 self.account.buy(
                     price=price,
                     amount=amount,

--- a/tests/test_atr_stops.py
+++ b/tests/test_atr_stops.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Add src directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from bot import Config, TraderBot, SymbolFetcher
+
+def make_df():
+    timestamps = pd.date_range("2024-01-01", periods=3, freq="min")
+    return pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": [10, 11, 12],
+            "high": [11, 13, 14],
+            "low": [9, 10, 11],
+            "close": [10, 12, 13],
+            "volume": [0, 0, 0],
+        }
+    )
+
+def compute_atr(df):
+    high_low = df["high"] - df["low"]
+    high_close = (df["high"] - df["close"].shift()).abs()
+    low_close = (df["low"] - df["close"].shift()).abs()
+    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
+    return tr.rolling(window=14, min_periods=1).mean().iloc[-1]
+
+def test_execute_trade_uses_atr(monkeypatch):
+    monkeypatch.setattr(SymbolFetcher, "start", lambda self: None)
+    df = make_df()
+    atr = compute_atr(df)
+    symbol = "TEST-USD"
+    price = df["close"].iloc[-1]
+    ts = df["timestamp"].iloc[-1]
+    atr_mult = 2.0
+    config = Config(symbol=symbol, atr_multiplier=atr_mult)
+    bot = TraderBot(config)
+    monkeypatch.setattr(bot, "fetch_candles", lambda symbol=None: df)
+    bot.execute_trade("buy", price, ts, symbol)
+    pos = bot.account.positions[symbol]
+    assert pos["stop_loss"] == pytest.approx(price - atr * atr_mult)
+    assert pos["take_profit"] == pytest.approx(price + atr * atr_mult)

--- a/tests/test_max_tokens.py
+++ b/tests/test_max_tokens.py
@@ -23,6 +23,17 @@ def test_execute_trade_respects_max_tokens(tmp_path, monkeypatch):
 
     config = Config(symbol=symbol, stake_usd=stake_usd, max_tokens=max_tokens)
     bot = TraderBot(config)
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-01-01", periods=2, freq="min"),
+            "open": [price, price],
+            "high": [price + 1, price + 2],
+            "low": [price - 1, price - 2],
+            "close": [price, price],
+            "volume": [0, 0],
+        }
+    )
+    monkeypatch.setattr(bot, "fetch_candles", lambda symbol=None: df)
 
     old_cwd = os.getcwd()
     os.chdir(tmp_path)

--- a/tests/test_trade_log.py
+++ b/tests/test_trade_log.py
@@ -45,6 +45,17 @@ def test_execute_trade_logs_amount(tmp_path, monkeypatch):
 
     config = Config(stake_usd=stake_usd, symbol=symbol)
     bot = TraderBot(config)
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-01-01", periods=2, freq="min"),
+            "open": [price, price],
+            "high": [price + 1, price + 2],
+            "low": [price - 1, price - 2],
+            "close": [price, price],
+            "volume": [0, 0],
+        }
+    )
+    monkeypatch.setattr(bot, "fetch_candles", lambda symbol=None: df)
 
     old_cwd = os.getcwd()
     os.chdir(tmp_path)


### PR DESCRIPTION
## Summary
- add `atr_multiplier` to bot configuration
- compute ATR from recent candles in `execute_trade` and use it for stop-loss/take-profit
- add tests for ATR-based stops and update existing tests with candle mocks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab95599254832c90ba3eb18028420e