### PR TITLE
Reuse exchange instance in symbol fetcher

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -65,6 +65,7 @@ class SymbolFetcher:
         self.min_price = min_price
         self.symbols: List[str] = []
         self._ready = threading.Event()
+        self.exchange = ccxt.binanceus()
         self._thread = threading.Thread(target=self._run, daemon=True)
 
     def start(self) -> None:
@@ -94,8 +95,7 @@ class SymbolFetcher:
                 usdt_pairs.sort(
                     key=lambda d: float(d.get("quoteVolume", 0)), reverse=True
                 )
-                exchange = ccxt.binanceus()
-                exchange.load_markets()
+                self.exchange.load_markets()
                 validated: List[str] = []
                 for d in usdt_pairs:
                     base = d["symbol"][:-4]
@@ -104,7 +104,7 @@ class SymbolFetcher:
                     if price < self.min_price:
                         continue
                     try:
-                        exchange.fetch_ticker(base + "/USDT")
+                        self.exchange.fetch_ticker(base + "/USDT")
                     except Exception as exc:
                         logging.info("Skipping symbol %s: %s", symbol, exc)
                         continue

--- a/tests/test_min_price_filter.py
+++ b/tests/test_min_price_filter.py
@@ -2,7 +2,6 @@ import sys
 from pathlib import Path
 import time
 import requests
-import ccxt
 import pytest
 
 # Add src directory to path
@@ -29,11 +28,11 @@ def test_symbol_fetcher_filters_low_price(monkeypatch):
             return {"symbol": pair}
 
     monkeypatch.setattr(requests, "get", lambda *args, **kwargs: DummyResponse())
-    monkeypatch.setattr(ccxt, "binanceus", lambda: DummyExchange())
     monkeypatch.setattr(time, "sleep", lambda _: (_ for _ in ()).throw(SystemExit))
 
     config = Config(min_price=1.0)
     fetcher = SymbolFetcher(min_price=config.min_price)
+    fetcher.exchange = DummyExchange()
     with pytest.raises(SystemExit):
         fetcher._run()
 


### PR DESCRIPTION
## Summary
- Instantiate ccxt.binanceus exchange once in SymbolFetcher and reuse it
- Update min price filter test to patch the persistent exchange object

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9554bdec832cb3a4647633db2c7b