### PR TITLE
Log trade fees in paper trades

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -157,6 +157,7 @@ class PaperAccount:
                     "price",
                     "amount",
                     "profit",
+                    "fee",
                     "duration",
                 ],
             )
@@ -209,6 +210,7 @@ class PaperAccount:
             "price": price,
             "amount": amount,
             "profit": "",
+            "fee": "",
             "duration": "",
         }
         self.log.append(entry)
@@ -251,6 +253,7 @@ class PaperAccount:
             "price": exit_price,
             "amount": amount,
             "profit": profit,
+            "fee": fee,
             "duration": duration.total_seconds(),
         }
         self.log.append(entry)

--- a/tests/test_trade_log.py
+++ b/tests/test_trade_log.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 # Add src directory to path for importing bot module
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
@@ -31,6 +32,7 @@ def test_trade_log_contains_symbol(tmp_path):
         os.chdir(old_cwd)
 
     assert rows and rows[0]["symbol"] == symbol
+    assert "fee" in rows[0]
 
 
 def test_execute_trade_logs_amount(tmp_path, monkeypatch):
@@ -58,3 +60,37 @@ def test_execute_trade_logs_amount(tmp_path, monkeypatch):
 
     assert rows, "No trades logged"
     assert float(rows[-1]["amount"]) == expected_amount
+    assert "fee" in rows[-1]
+
+
+def test_sell_logs_fee(tmp_path):
+    symbol = "TEST-USD"
+    config = Config()
+    account = PaperAccount(balance=1000.0, max_exposure=1.0, config=config)
+
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        buy_time = pd.Timestamp("2024-01-01")
+        sell_time = buy_time + pd.Timedelta(hours=1)
+        assert account.buy(
+            price=100.0, amount=1.0, timestamp=buy_time, symbol=symbol
+        )
+        sell_price = 110.0
+        fee_pct = 0.001
+        assert account.sell(
+            price=sell_price,
+            timestamp=sell_time,
+            symbol=symbol,
+            fee_pct=fee_pct,
+        )
+        with open("trade_log.csv", newline="") as f:
+            rows = list(csv.DictReader(f))
+    finally:
+        os.chdir(old_cwd)
+
+    assert len(rows) == 2
+    sell_row = rows[1]
+    expected_fee = sell_price * 1.0 * fee_pct
+    assert "fee" in sell_row
+    assert float(sell_row["fee"]) == pytest.approx(expected_fee)


### PR DESCRIPTION
## Summary
- Include fee field in PaperAccount trade logs and CSV header
- Record and log transaction fees during sells
- Test that trade logs include fee column and correct fee values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9543301c832caed6d1bacc6c922a