### PR TITLE
Use last price for equity calculations

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -135,9 +135,10 @@ class PaperAccount:
         self.config = config
 
     def get_equity(self) -> float:
-        """Return current account equity at entry prices."""
+        """Return current account equity using the most recent prices."""
         return self.balance + sum(
-            pos["price"] * pos["amount"] for pos in self.positions.values()
+            pos.get("last_price", pos["price"]) * pos["amount"]
+            for pos in self.positions.values()
         )
 
     def _log_to_file(self, entry: Dict) -> None:
@@ -527,6 +528,7 @@ class TraderBot:
                 timestamp = df["timestamp"].iloc[-1]
                 pos = self.account.positions.get(symbol)
                 if pos:
+                    pos["last_price"] = price
                     pos["highest_price"] = max(
                         pos.get("highest_price", pos["price"]), price
                     )
@@ -565,6 +567,8 @@ class TraderBot:
                 elif signal == "sell" and pos:
                     self.execute_trade("sell", price, timestamp, symbol)
                 pos = self.account.positions.get(symbol)
+                if pos:
+                    pos["last_price"] = price
                 if (
                     pos
                     and self.account.current_drawdown({symbol: price})

--- a/tests/test_equity_uses_last_price.py
+++ b/tests/test_equity_uses_last_price.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# add src directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from bot import Config, PaperAccount
+
+
+def test_equity_reflects_last_price():
+    symbol = "TEST-USD"
+    config = Config()
+    account = PaperAccount(balance=1000.0, max_exposure=1.0, config=config)
+    timestamp = pd.Timestamp("2024-01-01")
+    entry_price = 100.0
+    amount = 1.0
+
+    assert account.buy(price=entry_price, amount=amount, timestamp=timestamp, symbol=symbol)
+    # Equity initially reflects entry price
+    assert account.get_equity() == pytest.approx(1000.0)
+
+    # Update last_price and ensure equity uses it
+    account.positions[symbol]["last_price"] = 110.0
+    expected_equity = account.balance + 110.0 * amount
+    assert account.get_equity() == pytest.approx(expected_equity)


### PR DESCRIPTION
## Summary
- Update PaperAccount.get_equity to use each position's last_price when available
- Record last_price for open positions each iteration in TraderBot.run
- Add test ensuring equity reflects updated last_price values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9542f864832c8204987141fd6661