### PR TITLE
Ensure trailing stop overrides sell price

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -247,8 +247,8 @@ class PaperAccount:
         amount = pos["amount"]
         entry_price = pos["price"]
         exit_price = price
-        if trailing_stop is not None and trailing_stop < exit_price:
-            exit_price = trailing_stop
+        if trailing_stop is not None:
+            exit_price = min(trailing_stop, price)
         fee = exit_price * amount * fee_pct
         profit = (exit_price - entry_price) * amount - fee
         self.balance += exit_price * amount - fee

--- a/tests/test_trailing_stop.py
+++ b/tests/test_trailing_stop.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Add src directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from bot import Config, PaperAccount
+
+
+def test_trailing_stop_overrides_price():
+    config = Config(symbol="TEST-USD")
+    account = PaperAccount(balance=1000, max_exposure=1.0, config=config)
+    ts = pd.Timestamp("2024-01-01T00:00:00Z")
+    account.buy(price=100, amount=1, timestamp=ts, symbol="TEST-USD")
+    sell_ts = ts + pd.Timedelta(minutes=1)
+    account.sell(price=95, timestamp=sell_ts, symbol="TEST-USD", trailing_stop=90)
+    assert account.log[-1]["price"] == 90


### PR DESCRIPTION
## Summary
- Adjust PaperAccount.sell to let trailing stop override execution price
- Add test confirming trailing stop uses stop value for sell price

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d8537a4832c8d4f53040685c05f