### PR TITLE
Add configurable risk-based position sizing

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -26,6 +26,7 @@ class Config:
     timeframe: str = "1m"
     exchange: str = "binanceus"
     stake_usd: float = 100.0  # trade size in USD
+    risk_pct: float = 0.01  # fraction of equity to risk per trade
     max_tokens: float = float("inf")  # maximum token quantity per trade
     starting_balance: float = 1000.0
     max_exposure: float = 0.75  # fraction of account allowed in a single trade
@@ -484,13 +485,27 @@ class TraderBot:
                         self.config.min_edge_pct,
                     )
                     return
-                amount = self.config.stake_usd / price
-                logging.info(
-                    "Calculated trade amount %s for stake %.2f at price %.2f",
-                    amount,
-                    self.config.stake_usd,
-                    price,
-                )
+                if self.config.risk_pct > 0 and stop < price:
+                    equity = self.account.get_equity()
+                    risk_amount = equity * self.config.risk_pct
+                    stop_distance = price - stop
+                    amount = risk_amount / stop_distance
+                    logging.info(
+                        "Calculated trade amount %s risking %.2f (equity %.2f * risk_pct %.4f) with stop %.2f",
+                        amount,
+                        risk_amount,
+                        equity,
+                        self.config.risk_pct,
+                        stop,
+                    )
+                else:
+                    amount = self.config.stake_usd / price
+                    logging.info(
+                        "Calculated trade amount %s for stake %.2f at price %.2f",
+                        amount,
+                        self.config.stake_usd,
+                        price,
+                    )
                 if amount > self.config.max_tokens:
                     logging.warning(
                         "Amount %s exceeds max_tokens %s; capping",

--- a/tests/test_max_tokens.py
+++ b/tests/test_max_tokens.py
@@ -15,13 +15,13 @@ from bot import Config, TraderBot, SymbolFetcher
 def test_execute_trade_respects_max_tokens(tmp_path, monkeypatch):
     symbol = "TEST-USD"
     price = 10.0
-    stake_usd = 100.0
-    max_tokens = 5.0  # stake_usd/price = 10, so should cap at 5
+    risk_pct = 0.015
+    max_tokens = 5.0  # risk-based amount will exceed this and should cap
 
     # prevent background thread/network activity
     monkeypatch.setattr(SymbolFetcher, "start", lambda self: None)
 
-    config = Config(symbol=symbol, stake_usd=stake_usd, max_tokens=max_tokens)
+    config = Config(symbol=symbol, risk_pct=risk_pct, max_tokens=max_tokens, atr_multiplier=0)
     bot = TraderBot(config)
     df = pd.DataFrame(
         {

--- a/tests/test_risk_pct.py
+++ b/tests/test_risk_pct.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Add src directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from bot import Config, TraderBot, SymbolFetcher
+
+
+def test_risk_pct_affects_trade_size(monkeypatch):
+    symbol = "TEST-USD"
+    price = 10.0
+    timestamp = pd.Timestamp("2024-01-01")
+
+    # prevent background thread/network activity
+    monkeypatch.setattr(SymbolFetcher, "start", lambda self: None)
+
+    config_low = Config(
+        symbol=symbol,
+        risk_pct=0.01,
+        atr_multiplier=0,
+        max_exposure=1.0,
+        stop_loss_pct=0.05,
+    )
+    bot_low = TraderBot(config_low)
+    bot_low.execute_trade("buy", price, timestamp, symbol)
+    amount_low = bot_low.account.positions[symbol]["amount"]
+
+    config_high = Config(
+        symbol=symbol,
+        risk_pct=0.02,
+        atr_multiplier=0,
+        max_exposure=1.0,
+        stop_loss_pct=0.05,
+    )
+    bot_high = TraderBot(config_high)
+    bot_high.execute_trade("buy", price, timestamp, symbol)
+    amount_high = bot_high.account.positions[symbol]["amount"]
+
+    assert amount_high == pytest.approx(amount_low * 2)
+


### PR DESCRIPTION
## Summary
- Add `risk_pct` to bot configuration to limit equity risk per trade
- Size buy orders using `risk_pct` and stop-loss distance for consistent risk
- Extend tests to cover risk-based sizing and update existing tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d9190e0832c9a166d9175287da7