### PR TITLE
Fix trailing stop equality in PaperAccount.sell

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -257,7 +257,7 @@ class PaperAccount:
         amount = pos["amount"]
         entry_price = pos["price"]
         exit_price = price * (1 - self.config.spread_pct / 2)
-        if trailing_stop is not None and trailing_stop < exit_price:
+        if trailing_stop is not None and trailing_stop <= exit_price:
             exit_price = trailing_stop * (1 - self.config.spread_pct / 2)
         fee = exit_price * amount * fee_pct
         profit = (exit_price - entry_price) * amount - fee

--- a/tests/test_trailing_stop.py
+++ b/tests/test_trailing_stop.py
@@ -37,3 +37,32 @@ def test_sell_uses_trailing_stop_price(tmp_path, spread_pct):
         assert sell_entry["price"] == pytest.approx(expected_price)
     finally:
         os.chdir(old_cwd)
+
+
+@pytest.mark.parametrize("spread_pct", [0.0, 0.02])
+def test_trailing_stop_equals_price(tmp_path, spread_pct):
+    config = Config(spread_pct=spread_pct)
+    account = PaperAccount(balance=1000.0, max_exposure=1.0, config=config)
+
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        ts = pd.Timestamp("2024-01-01")
+        symbol = "BTC-USD"
+        assert account.buy(price=100.0, amount=1.0, timestamp=ts, symbol=symbol)
+
+        price = 90.0
+        trailing_stop = price
+        assert account.sell(
+            price=price,
+            timestamp=ts + pd.Timedelta(minutes=1),
+            symbol=symbol,
+            fee_pct=0.0,
+            trailing_stop=trailing_stop,
+        )
+
+        sell_entry = account.log[-1]
+        expected_price = trailing_stop * (1 - spread_pct / 2)
+        assert sell_entry["price"] == pytest.approx(expected_price)
+    finally:
+        os.chdir(old_cwd)


### PR DESCRIPTION
## Summary
- allow trailing stop to execute when stop price equals exit price
- add regression test for trailing_stop == price to ensure stop executes at stop price

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad30b16b8c832cad99a1d372ba6086