### PR TITLE
Include buy fees in net profit calculations

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -219,6 +219,7 @@ class PaperAccount:
             "take_profit": take_profit,
             "highest_price": effective_price,
             "trailing_stop_pct": trailing_stop_pct,
+            "buy_fee": fee,
         }
         self.peak_balance = max(self.peak_balance, self.balance)
         entry = {
@@ -260,7 +261,9 @@ class PaperAccount:
         if trailing_stop is not None and trailing_stop < exit_price:
             exit_price = trailing_stop * (1 - self.config.spread_pct / 2)
         fee = exit_price * amount * fee_pct
-        profit = (exit_price - entry_price) * amount - fee
+        buy_fee = float(pos.get("buy_fee", 0.0))
+        total_fee = fee + buy_fee
+        profit = (exit_price - entry_price) * amount - total_fee
         self.balance += exit_price * amount - fee
         self.peak_balance = max(self.peak_balance, self.balance)
         duration = timestamp - pos["timestamp"]
@@ -271,7 +274,7 @@ class PaperAccount:
             "price": exit_price,
             "amount": amount,
             "profit": profit,
-            "fee": fee,
+            "fee": total_fee,
             "duration": duration.total_seconds(),
         }
         self.log.append(entry)

--- a/tests/test_analyze_log.py
+++ b/tests/test_analyze_log.py
@@ -24,8 +24,8 @@ def test_analyze_basic(tmp_path, capsys):
             "side": "sell",
             "price": 110.0,
             "amount": 1.0,
-            "profit": 10.0,
-            "fee": 0.0,
+            "profit": 8.5,
+            "fee": 1.5,
             "duration": 60.0,
         },
         {
@@ -44,8 +44,8 @@ def test_analyze_basic(tmp_path, capsys):
             "side": "sell",
             "price": 90.0,
             "amount": 1.0,
-            "profit": -10.0,
-            "fee": 0.0,
+            "profit": -11.5,
+            "fee": 1.5,
             "duration": 60.0,
         },
     ]
@@ -54,6 +54,6 @@ def test_analyze_basic(tmp_path, capsys):
     df.to_csv(path, index=False)
     analyze(str(path))
     captured = capsys.readouterr().out
-    assert "Net profit: -2.00" in captured
+    assert "Net profit: -3.00" in captured
     assert "Win rate: 50.0% (1/2)" in captured
-    assert "AAA-USD: -2.00" in captured
+    assert "AAA-USD: -3.00" in captured

--- a/tests/test_trade_log.py
+++ b/tests/test_trade_log.py
@@ -123,16 +123,22 @@ def test_sell_logs_fee(tmp_path):
     try:
         buy_time = pd.Timestamp("2024-01-01")
         sell_time = buy_time + pd.Timedelta(hours=1)
-        assert account.buy(
-            price=100.0, amount=1.0, timestamp=buy_time, symbol=symbol
-        )
+        buy_fee_pct = 0.001
+        sell_fee_pct = 0.002
+        buy_price = 100.0
         sell_price = 110.0
-        fee_pct = 0.001
+        assert account.buy(
+            price=buy_price,
+            amount=1.0,
+            timestamp=buy_time,
+            symbol=symbol,
+            fee_pct=buy_fee_pct,
+        )
         assert account.sell(
             price=sell_price,
             timestamp=sell_time,
             symbol=symbol,
-            fee_pct=fee_pct,
+            fee_pct=sell_fee_pct,
         )
         with open("trade_log.csv", newline="") as f:
             rows = list(csv.DictReader(f))
@@ -141,9 +147,13 @@ def test_sell_logs_fee(tmp_path):
 
     assert len(rows) == 2
     sell_row = rows[1]
-    expected_fee = sell_price * 1.0 * fee_pct
+    expected_buy_fee = buy_price * 1.0 * buy_fee_pct
+    expected_sell_fee = sell_price * 1.0 * sell_fee_pct
+    expected_fee = expected_buy_fee + expected_sell_fee
+    expected_profit = (sell_price - buy_price) - expected_fee
     assert "fee" in sell_row
     assert float(sell_row["fee"]) == pytest.approx(expected_fee)
+    assert float(sell_row["profit"]) == pytest.approx(expected_profit)
 
 
 def test_spread_adjusts_pnl(tmp_path):


### PR DESCRIPTION
## Summary
- Track buy-side fees in open positions and subtract them from profits when closing, logging the total fees for each trade
- Simplify `analyze_log` to sum sell-side profits directly, matching the new fee handling
- Extend trade log and analysis tests to assert profits net of both buy and sell fees

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad30c3ed30832c9a3738e7369dd827