### PR TITLE
Use spread-adjusted price for stop distance calculation

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -525,7 +525,8 @@ class TraderBot:
                 if self.config.risk_pct > 0 and stop < price:
                     equity = self.account.get_equity()
                     risk_amount = equity * self.config.risk_pct
-                    stop_distance = price - stop
+                    entry_price = price * (1 + self.config.spread_pct / 2)
+                    stop_distance = entry_price - stop
                     amount = risk_amount / stop_distance
                     logging.info(
                         "Calculated trade amount %s risking %.2f (equity %.2f * risk_pct %.4f) with stop %.2f",


### PR DESCRIPTION
## Summary
- Adjust risk-based position sizing to use spread-adjusted entry price when computing stop distance
- Add tests to verify risk percentage sizing and spread-aware sizing

## Testing
- `pytest tests/test_risk_pct.py -q`
- `pytest -q` *(fails: tests/test_analyze_log.py::test_analyze_basic, tests/test_analyze_log.py::test_analyze_directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3683fbf8832cbfd75c25447344a0