### PR TITLE
chore: remove unused defaultdict import

### DIFF
--- a/src/analyze_log.py
+++ b/src/analyze_log.py
@@ -1,5 +1,4 @@
 import argparse
-from collections import defaultdict
 from typing import Dict, List, Optional
 import os
 


### PR DESCRIPTION
## Summary
- drop unused `defaultdict` import from `analyze_log`

## Testing
- `python -m py_compile src/analyze_log.py`
- `pytest` *(fails: 2 failed, 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad36840d30832cbec0a0eacd48b90b