### PR TITLE
Add capital-aware trade sizing and logging

### DIFF
--- a/tests/test_stop_distance_and_capital.py
+++ b/tests/test_stop_distance_and_capital.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import logging
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+from bot import Config, TraderBot, SymbolFetcher
+
+
+def test_execute_trade_skips_on_zero_stop_distance(monkeypatch, caplog):
+    symbol = "TEST-USD"
+    price = 100.0
+    timestamp = pd.Timestamp("2024-01-01")
+    monkeypatch.setattr(SymbolFetcher, "start", lambda self: None)
+    config = Config(
+        symbol=symbol,
+        risk_pct=0.01,
+        atr_multiplier=0,
+        stop_loss_pct=0.01,
+        spread_pct=-0.02,
+    )
+    bot = TraderBot(config)
+    with caplog.at_level(logging.WARNING):
+        bot.execute_trade("buy", price, timestamp, symbol)
+    assert symbol not in bot.account.positions
+    assert any("non-positive stop distance" in rec.message for rec in caplog.records)
+
+
+def test_execute_trade_falls_back_when_exceeds_capital(monkeypatch, caplog):
+    symbol = "TEST-USD"
+    price = 10.0
+    timestamp = pd.Timestamp("2024-01-01")
+    monkeypatch.setattr(SymbolFetcher, "start", lambda self: None)
+    config = Config(
+        symbol=symbol,
+        risk_pct=0.1,
+        atr_multiplier=0,
+        stop_loss_pct=0.01,
+        stake_usd=100.0,
+        max_exposure=0.5,
+    )
+    bot = TraderBot(config)
+    with caplog.at_level(logging.INFO):
+        bot.execute_trade("buy", price, timestamp, symbol)
+    pos = bot.account.positions[symbol]
+    assert pos["amount"] == pytest.approx(config.stake_usd / price)
+    assert any("capital limit" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- Validate stop distance before risk-based sizing and skip trades with non-positive distance
- Cap risk-based trade amounts by available balance and fall back to stake sizing when necessary
- Handle fees more flexibly during log analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad4f547c68832c94cf930ff0ca1be2