### PR TITLE
Set default trading costs and update tests

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -43,7 +43,7 @@ class Config:
     summary_interval: int = 300  # seconds between status summaries
     pnl_window: int = 10  # number of closed trades to evaluate per-symbol PnL
     min_profit_threshold: float = 0.0  # minimum profit to keep trading a symbol
-    fee_pct: float = 0.0  # exchange fee percentage applied on sells
+    fee_pct: float = 0.001  # exchange fee percentage applied on sells
     trailing_stop_pct: float = 0.0  # percentage for trailing stop (0 to disable)
     max_holding_minutes: int = 60  # maximum duration to hold a position
     rsi_period: int = 14  # period for RSI calculation
@@ -51,8 +51,8 @@ class Config:
     rsi_sell_threshold: float = 45.0  # maximum RSI for sell signals
     rsi_std_multiplier: float = 1.0  # std-dev multiplier for adaptive RSI
     ema_threshold_mult: float = 0.0  # volatility factor for EMA crossover
-    spread_pct: float = 0.0  # estimated bid/ask spread percentage
-    min_edge_pct: float = 0.0  # minimum edge required after costs
+    spread_pct: float = 0.0005  # estimated bid/ask spread percentage
+    min_edge_pct: float = 0.0015  # minimum edge required after costs
     min_price: float = 0.0  # minimum token price to include
 
 

--- a/tests/test_symbol_pnl.py
+++ b/tests/test_symbol_pnl.py
@@ -9,7 +9,7 @@ from bot import Config, PaperAccount
 
 
 def test_pnl_by_symbol_window():
-    config = Config()
+    config = Config(fee_pct=0.0, spread_pct=0.0)
     account = PaperAccount(balance=1000.0, max_exposure=1.0, config=config)
     ts = pd.Timestamp("2024-01-01")
 

--- a/tests/test_trade_log.py
+++ b/tests/test_trade_log.py
@@ -14,7 +14,7 @@ from bot import Config, PaperAccount, TraderBot, SymbolFetcher
 
 def test_trade_log_contains_symbol(tmp_path):
     symbol = "TEST-USD"
-    config = Config()
+    config = Config(fee_pct=0.0, spread_pct=0.0)
     account = PaperAccount(balance=1000.0, max_exposure=1.0, config=config)
 
     # operate within temporary directory
@@ -52,6 +52,7 @@ def test_execute_trade_logs_amount(tmp_path, monkeypatch):
         risk_pct=risk_pct,
         symbol=symbol,
         fee_pct=fee_pct,
+        spread_pct=0.0,
         atr_multiplier=0,
         starting_balance=equity,
     )
@@ -86,7 +87,7 @@ def test_execute_trade_logs_amount(tmp_path, monkeypatch):
 
 def test_buy_logs_fee(tmp_path):
     symbol = "TEST-USD"
-    config = Config()
+    config = Config(fee_pct=0.0, spread_pct=0.0)
     account = PaperAccount(balance=1000.0, max_exposure=1.0, config=config)
 
     old_cwd = os.getcwd()
@@ -115,7 +116,7 @@ def test_buy_logs_fee(tmp_path):
 
 def test_sell_logs_fee(tmp_path):
     symbol = "TEST-USD"
-    config = Config()
+    config = Config(fee_pct=0.0, spread_pct=0.0)
     account = PaperAccount(balance=1000.0, max_exposure=1.0, config=config)
 
     old_cwd = os.getcwd()


### PR DESCRIPTION
## Summary
- set realistic default trading costs in `Config`
- ensure trade tests disable costs explicitly

## Testing
- `python - <<'PY'` (paper trade, edge too small)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae87e0beb8832c95628806f32b1a60