### PR TITLE
Add minimum symbol profitability threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install -r requirements.txt
 
 Configuration such as trading pair, exchange (default `binanceus`), stop‑loss/take‑profit percentages, drawdown limit, starting balance, and exposure limits can be adjusted in the `Config` dataclass inside `src/bot.py`. The exchange value determines which CCXT exchange provides price data.
 
-The bot tracks profit and loss by symbol. Use `pnl_window` to set the number of recent closed trades to evaluate and `min_profit_threshold` to require a minimum cumulative profit before continuing to trade a symbol. Symbols whose PnL over the configured window falls below the threshold are skipped.
+The bot tracks profit and loss by symbol. Use `pnl_window` to set the number of recent closed trades to evaluate and `min_profit_threshold` (default `0.1`) to require a minimum cumulative profit before continuing to trade a symbol. A symbol must earn at least this amount over the configured window before further trades are allowed; otherwise it is skipped. Set the threshold to `0` to disable this check.
 
 The strategy also calculates a 14-period Relative Strength Index (RSI) and only allows a trade when this value is above `rsi_buy_threshold` (default 55) for buys or below `rsi_sell_threshold` (default 45) for sells. The RSI period and thresholds are configurable via `rsi_period`, `rsi_buy_threshold`, and `rsi_sell_threshold` in `Config`.
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -42,7 +42,7 @@ class Config:
     stop_on_drawdown: bool = True  # stop bot instead of pausing on drawdown
     summary_interval: int = 300  # seconds between status summaries
     pnl_window: int = 10  # number of closed trades to evaluate per-symbol PnL
-    min_profit_threshold: float = 0.0  # minimum profit to keep trading a symbol
+    min_profit_threshold: float = 0.1  # minimum profit to keep trading a symbol
     fee_pct: float = 0.001  # exchange fee percentage applied on sells
     trailing_stop_pct: float = 0.0  # percentage for trailing stop (0 to disable)
     max_holding_minutes: int = 60  # maximum duration to hold a position
@@ -623,7 +623,9 @@ class TraderBot:
                 if not symbol:
                     logging.warning("Encountered empty symbol; skipping trade execution")
                     continue
-                pnl = self.account.pnl_by_symbol(self.config.pnl_window).get(symbol, 0.0)
+                pnl = self.account.pnl_by_symbol(self.config.pnl_window).get(
+                    symbol, self.config.min_profit_threshold
+                )
                 if pnl < self.config.min_profit_threshold:
                     logging.info(
                         "Skipping %s due to PnL %.2f below threshold %.2f",


### PR DESCRIPTION
## Summary
- require symbols show small profit before further trades
- skip symbols until their PnL meets `min_profit_threshold`
- document symbol profitability threshold in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae88fe2b2c832c952e97f8b1f5e94a