### PR TITLE
Slow default config and document reduced trade frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository explores building an autonomous cryptocurrency trading bot.
 
 The example bot in `src/bot.py` fetches price data from cryptocurrency exchanges via the [`ccxt`](https://github.com/ccxt/ccxt) library (default `binanceus`) and demonstrates a simple moving average crossover strategy. A built-in paper trading account simulates trades with a starting balance of $1000 and a maximum exposure of 75% of the account. Each trade is logged to `trade_log.csv` with profit or loss and the duration the position was held. Stop‑loss and take‑profit levels are applied to every position, and the bot halts if account drawdown exceeds a configurable threshold.
 
+By default the bot uses a 5‑minute timeframe with 20/50 EMA spans and RSI thresholds of 60/40. This slower configuration reduces trade frequency and may improve win rate by filtering out some market noise.
+
 
 ## Disclaimer
 This project is for educational purposes only and does not constitute financial or investment advice. Use at your own risk.
@@ -30,9 +32,9 @@ Configuration such as trading pair, exchange (default `binanceus`), stop‑loss/
 
 The bot tracks profit and loss by symbol. Use `pnl_window` to set the number of recent closed trades to evaluate and `min_profit_threshold` (default `0.1`) to require a minimum cumulative profit before continuing to trade a symbol. A symbol must earn at least this amount over the configured window before further trades are allowed; otherwise it is skipped. Set the threshold to `0` to disable this check.
 
-The strategy also calculates a 14-period Relative Strength Index (RSI) and only allows a trade when this value is above `rsi_buy_threshold` (default 55) for buys or below `rsi_sell_threshold` (default 45) for sells. The RSI period and thresholds are configurable via `rsi_period`, `rsi_buy_threshold`, and `rsi_sell_threshold` in `Config`.
+The strategy also calculates a 14-period Relative Strength Index (RSI) and only allows a trade when this value is above `rsi_buy_threshold` (default 60) for buys or below `rsi_sell_threshold` (default 40) for sells. The RSI period and thresholds are configurable via `rsi_period`, `rsi_buy_threshold`, and `rsi_sell_threshold` in `Config`.
 
-To control how often the strategy trades, adjust the `timeframe` along with the `ema_fast_span` and `ema_slow_span` settings in `Config`. Shorter timeframes like `"1m"` or `"5m"` provide more frequent price updates, while smaller EMA spans make crossovers more responsive. These tweaks are useful to trigger trades during brief test runs. For example:
+To control how often the strategy trades, adjust the `timeframe` along with the `ema_fast_span` and `ema_slow_span` settings in `Config`. Shorter timeframes like `"1m"` provide more frequent price updates, while smaller EMA spans make crossovers more responsive. The default 5‑minute timeframe with 20/50 spans trades less often, which may improve win rate. These tweaks are useful to trigger trades during brief test runs. For example:
 
 ```python
 Config(timeframe="1m", ema_fast_span=5, ema_slow_span=15)

--- a/src/bot.py
+++ b/src/bot.py
@@ -25,7 +25,7 @@ logging.basicConfig(level=logging.INFO)
 class Config:
 
     symbol: str = "BTC-USD"
-    timeframe: str = "1m"
+    timeframe: str = "5m"
     exchange: str = "binanceus"
     stake_usd: float = 100.0  # trade size in USD
     risk_pct: float = 0.01  # fraction of equity to risk per trade
@@ -36,8 +36,8 @@ class Config:
     take_profit_pct: float = 0.04  # 4% take profit target
     atr_multiplier: float = 1.0  # ATR multiple for stop-loss and take-profit
     max_drawdown_pct: float = 0.2  # stop trading if drawdown exceeds 20%
-    ema_fast_span: int = 12  # fast EMA span for crossover
-    ema_slow_span: int = 26  # slow EMA span for crossover
+    ema_fast_span: int = 20  # fast EMA span for crossover
+    ema_slow_span: int = 50  # slow EMA span for crossover
     drawdown_cooldown: int = 300  # seconds to pause after max drawdown
     stop_on_drawdown: bool = True  # stop bot instead of pausing on drawdown
     summary_interval: int = 300  # seconds between status summaries
@@ -47,8 +47,8 @@ class Config:
     trailing_stop_pct: float = 0.01  # percentage for trailing stop (0 to disable)
     max_holding_minutes: int = 60  # maximum duration to hold a position
     rsi_period: int = 14  # period for RSI calculation
-    rsi_buy_threshold: float = 55.0  # minimum RSI for buy signals
-    rsi_sell_threshold: float = 45.0  # maximum RSI for sell signals
+    rsi_buy_threshold: float = 60.0  # minimum RSI for buy signals
+    rsi_sell_threshold: float = 40.0  # maximum RSI for sell signals
     rsi_std_multiplier: float = 1.0  # std-dev multiplier for adaptive RSI
     ema_threshold_mult: float = 0.0  # volatility factor for EMA crossover
     spread_pct: float = 0.0005  # estimated bid/ask spread percentage

--- a/tests/test_ema_crossover.py
+++ b/tests/test_ema_crossover.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Add src directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from bot import Config, TraderBot, SymbolFetcher
+
+
+def make_df(closes):
+    timestamps = pd.date_range("2024-01-01", periods=len(closes), freq="min")
+    return pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": closes,
+            "high": closes,
+            "low": closes,
+            "close": closes,
+            "volume": [0] * len(closes),
+        }
+    )
+
+
+def test_ema_crossover(monkeypatch):
+    # prevent background thread/network activity
+    monkeypatch.setattr(SymbolFetcher, "start", lambda self: None)
+    monkeypatch.setattr(SymbolFetcher, "wait_until_ready", lambda self, timeout=None: None)
+
+    df_buy = make_df([100] * 50 + [110])
+    df_sell = make_df([100] * 50 + [90])
+
+    bot = TraderBot(Config(symbol="T-USD"))
+    assert bot.generate_signal(df_buy) == "buy"
+    assert bot.generate_signal(df_sell) == "sell"


### PR DESCRIPTION
## Summary
- Slow down default strategy to 5m candles with 20/50 EMA spans and tighter RSI thresholds
- Document that the slower defaults reduce trade frequency and may improve win rate
- Add regression test ensuring generate_signal fires on EMA crossovers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae8a7479a8832c9f94a41d1e34752b