### PR TITLE
Warn when take-profit target fails to cover costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ pip install -r requirements.txt
 
 Configuration such as trading pair, exchange (default `binanceus`), stop‑loss/take‑profit percentages, drawdown limit, starting balance, and exposure limits can be adjusted in the `Config` dataclass inside `src/bot.py`. The exchange value determines which CCXT exchange provides price data.
 
+Because every trade pays fees and crosses the bid/ask spread, the bot only
+enters positions when the profit target exceeds these costs plus a minimum
+required edge. Total trading costs are computed as `fee_pct*2 + spread_pct`
+and compared against `take_profit_pct - min_edge_pct`. If the target is too
+small to cover costs and the desired edge, the bot logs a warning and skips
+trades.
+
 The bot tracks profit and loss by symbol. Use `pnl_window` to set the number of recent closed trades to evaluate and `min_profit_threshold` (default `0.1`) to require a minimum cumulative profit before continuing to trade a symbol. A symbol must earn at least this amount over the configured window before further trades are allowed; otherwise it is skipped. Set the threshold to `0` to disable this check.
 
 The strategy also calculates a 14-period Relative Strength Index (RSI) and only allows a trade when this value is above `rsi_buy_threshold` (default 60) for buys or below `rsi_sell_threshold` (default 40) for sells. The RSI period and thresholds are configurable via `rsi_period`, `rsi_buy_threshold`, and `rsi_sell_threshold` in `Config`.


### PR DESCRIPTION
## Summary
- Precompute combined entry/exit fees and spread as trading costs and warn when `take_profit_pct` is too small to clear costs plus `min_edge_pct`
- Document how `take_profit_pct`, fees, spread, and `min_edge_pct` interact in both the `Config` dataclass and README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afde9582fc832c92ea2ea6fd7b97d5