### PR TITLE
Add configurable debug logging for strategy decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ pip install -r requirements.txt
 
 Configuration such as trading pair, exchange (default `binanceus`), stop‑loss/take‑profit percentages, drawdown limit, starting balance, and exposure limits can be adjusted in the `Config` dataclass inside `src/bot.py`. The exchange value determines which CCXT exchange provides price data.
 
+Set `debug_logging=True` in `Config` to enable additional `logging.debug` messages that explain when RSI/EMA conditions fail or when orders are skipped because of edge, PnL threshold, or exposure limits.
+
 
 `stake_usd` and `risk_pct` set trade size; at least one of them must be greater than zero. `max_tokens` also needs to be a positive number. The bot validates these minimum values on startup and raises an error if the resulting trade size is not positive.
 


### PR DESCRIPTION
## Summary
- add `debug_logging` option to Config and initialize root logger accordingly
- emit debug logs when RSI/EMA conditions fail and when trades are skipped for edge, PnL, or exposure limits
- document `debug_logging` usage in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a54688ac832c8a7c61c373f4a75b