### PR TITLE
Add optional RSI filter and CLI toggle

### DIFF
--- a/tests/test_rsi_signal.py
+++ b/tests/test_rsi_signal.py
@@ -43,3 +43,21 @@ def test_rsi_threshold(monkeypatch):
 
     bot_allow_sell = TraderBot(Config(symbol="T-USD", rsi_sell_threshold=50))
     assert bot_allow_sell.generate_signal(df_sell) == "sell"
+
+
+def test_disable_rsi_filter_allows_signals(monkeypatch):
+    monkeypatch.setattr(SymbolFetcher, "start", lambda self: None)
+    monkeypatch.setattr(SymbolFetcher, "wait_until_ready", lambda self, timeout=None: None)
+
+    df_buy = make_df([100] * 50 + [110])
+    df_sell = make_df([100] * 50 + [90])
+
+    bot_buy = TraderBot(
+        Config(symbol="T-USD", rsi_buy_threshold=100, use_rsi_filter=False)
+    )
+    assert bot_buy.generate_signal(df_buy) == "buy"
+
+    bot_sell = TraderBot(
+        Config(symbol="T-USD", rsi_sell_threshold=-1, use_rsi_filter=False)
+    )
+    assert bot_sell.generate_signal(df_sell) == "sell"


### PR DESCRIPTION
## Summary
- add `use_rsi_filter` flag to `Config` allowing RSI checks to be disabled
- gate RSI thresholds in `TraderBot.generate_signal` behind the flag
- expose `--no-rsi-filter` CLI option for quick experimentation
- test that disabling the filter still produces signals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfc03a8738832c825fc0ff284eec40