### PR TITLE
Log insufficient edge and add edge override flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Set `debug_logging=True` in `Config` to enable additional `logging.debug` messag
 
 Because every trade pays fees and crosses the bid/ask spread, the bot only
 enters positions when the profit target exceeds these costs plus a minimum
-required edge. Total trading costs are computed as `fee_pct*2 + spread_pct`
-and compared against `take_profit_pct - min_edge_pct`. If the target is too
-small to cover costs and the desired edge, the bot logs a warning and skips
-trades.
+required edge. Total trading costs (`costs`) are computed as `fee_pct*2 + spread_pct`.
+The trade's `edge` is `take_profit_pct - costs`, and a trade executes only when
+`edge >= min_edge_pct`. If the edge is too small, the bot logs a warning and skips
+the trade. You can temporarily relax this requirement with the
+`--min-edge-pct` command-line option.
 
 To guarantee enough cushion, choose a `take_profit_pct` that at least equals
 `fee_pct*2 + spread_pct + min_edge_pct`. This covers trading costs and still

--- a/src/bot.py
+++ b/src/bot.py
@@ -699,6 +699,11 @@ class TraderBot:
             if pos:
                 gain_pct = (price - pos["price"]) / pos["price"] - costs
                 if gain_pct < self.config.min_edge_pct:
+                    logging.info(
+                        "Sell skipped: edge %.4f below minimum %.4f",
+                        gain_pct,
+                        self.config.min_edge_pct,
+                    )
                     logging.debug(
                         "Sell skipped: edge %.4f below minimum %.4f",
                         gain_pct,
@@ -866,6 +871,12 @@ if __name__ == "__main__":
         default=None,
     )
     parser.add_argument(
+        "--min-edge-pct",
+        type=float,
+        help="Override minimum edge required after costs",
+        default=None,
+    )
+    parser.add_argument(
         "--no-rsi-filter",
         action="store_false",
         dest="use_rsi_filter",
@@ -889,6 +900,8 @@ if __name__ == "__main__":
         cfg_kwargs["ema_fast_span"] = args.ema_fast_span
     if args.ema_slow_span is not None:
         cfg_kwargs["ema_slow_span"] = args.ema_slow_span
+    if args.min_edge_pct is not None:
+        cfg_kwargs["min_edge_pct"] = args.min_edge_pct
     if args.use_rsi_filter is not None:
         cfg_kwargs["use_rsi_filter"] = args.use_rsi_filter
 


### PR DESCRIPTION
## Summary
- Log required and actual edge before skipping sell trades
- Add --min-edge-pct option to override Config.min_edge_pct from CLI
- Document how costs and edge interact, including the new override option

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfc256478c832c9809331fcf04c89b