### PR TITLE
feat: add symbol fallback and CLI override

### DIFF
--- a/tests/test_reset_pnl.py
+++ b/tests/test_reset_pnl.py
@@ -20,7 +20,11 @@ class DummyFetcher:
 
 def test_reset_pnl(monkeypatch):
     # Avoid network calls by stubbing out SymbolFetcher
-    monkeypatch.setattr(bot_module, "SymbolFetcher", lambda min_price=0.0: DummyFetcher())
+    monkeypatch.setattr(
+        bot_module,
+        "SymbolFetcher",
+        lambda min_price=0.0, fallback_symbols=None: DummyFetcher(),
+    )
 
     cfg = Config(min_profit_threshold=0.1)
     bot = TraderBot(cfg)


### PR DESCRIPTION
## Summary
- allow specifying fallback symbols via config or `--symbols` CLI argument
- log warnings and use fallback list when automatic symbol fetching fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05b562240832cb5d92ce96111c82b