### PR TITLE
Surface signal rejection details via debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,14 @@ pip install -r requirements.txt
 
 Configuration such as trading pair, exchange (default `binanceus`), stop‑loss/take‑profit percentages, drawdown limit, starting balance, and exposure limits can be adjusted in the `Config` dataclass inside `src/bot.py`. The exchange value determines which CCXT exchange provides price data.
 
-Set `debug_logging=True` in `Config` to enable additional `logging.debug` messages that explain when RSI/EMA conditions fail or when orders are skipped because of edge, PnL threshold, or exposure limits.
+Set `debug_logging=True` in `Config` to enable additional messages that explain when RSI/EMA conditions fail or when orders are skipped because of edge, PnL threshold, or exposure limits. When enabled, these diagnostics are logged at the `INFO` level so they appear with default logging settings.
 
+Common rejection messages and their meanings:
+
+- `Buy EMA condition failed` – the fast EMA has not crossed above the slow EMA by the required margin.
+- `Buy RSI condition failed` – the RSI value is at or below the configured buy threshold.
+- `Sell EMA condition failed` – the fast EMA has not crossed below the slow EMA by the required margin.
+- `Sell RSI condition failed` – the RSI value is at or above the configured sell threshold.
 
 `stake_usd` and `risk_pct` set trade size; at least one of them must be greater than zero. `max_tokens` also needs to be a positive number. The bot validates these minimum values on startup and raises an error if the resulting trade size is not positive.
 

--- a/src/strategies/ema_rsi.py
+++ b/src/strategies/ema_rsi.py
@@ -6,6 +6,8 @@ import pandas as pd
 
 def generate_signal(df: pd.DataFrame, config) -> Optional[str]:
     """Generate a moving average crossover signal filtered by RSI."""
+    log = logging.info if getattr(config, "debug_logging", False) else logging.debug
+
     df["ema_fast"] = df["close"].ewm(span=config.ema_fast_span).mean()
     df["ema_slow"] = df["close"].ewm(span=config.ema_slow_span).mean()
 
@@ -44,14 +46,14 @@ def generate_signal(df: pd.DataFrame, config) -> Optional[str]:
     if buy_ema and (not config.use_rsi_filter or buy_rsi):
         return "buy"
     if not buy_ema:
-        logging.debug(
+        log(
             "Buy EMA condition failed: diff %.4f (prev %.4f) threshold %.4f",
             ema_curr,
             ema_prev,
             ema_threshold,
         )
     if config.use_rsi_filter and not buy_rsi:
-        logging.debug(
+        log(
             "Buy RSI condition failed: %.2f <= %.2f",
             rsi_now,
             buy_thresh,
@@ -61,14 +63,14 @@ def generate_signal(df: pd.DataFrame, config) -> Optional[str]:
     if sell_ema and (not config.use_rsi_filter or sell_rsi):
         return "sell"
     if not sell_ema:
-        logging.debug(
+        log(
             "Sell EMA condition failed: diff %.4f (prev %.4f) threshold -%.4f",
             ema_curr,
             ema_prev,
             ema_threshold,
         )
     if config.use_rsi_filter and not sell_rsi:
-        logging.debug(
+        log(
             "Sell RSI condition failed: %.2f >= %.2f",
             rsi_now,
             sell_thresh,


### PR DESCRIPTION
## Summary
- Elevate failed EMA/RSI condition logs to INFO when `debug_logging` is enabled, making discarded signal reasons visible.
- Document each rejection message and its meaning for easier troubleshooting.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05db47c14832c97bc8a5d5e2aa570