### PR TITLE
Add Bollinger breakout strategy

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -903,7 +903,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--strategy",
         type=str,
-        help="Strategy module name (e.g., ema_rsi, rsi_mean)",
+        help="Strategy module name (e.g., ema_rsi, rsi_mean, bollinger_breakout)",
         default=None,
     )
     parser.add_argument(

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,0 +1,4 @@
+"""Strategy modules for MaxTraderAI."""
+from . import ema_rsi, rsi_mean, bollinger_breakout
+
+__all__ = ["ema_rsi", "rsi_mean", "bollinger_breakout"]

--- a/src/strategies/bollinger_breakout.py
+++ b/src/strategies/bollinger_breakout.py
@@ -1,0 +1,28 @@
+"""Bollinger Band breakout strategy."""
+from typing import Optional
+import pandas as pd
+
+
+def generate_signal(df: pd.DataFrame, config) -> Optional[str]:
+    """Return "buy" if price closes above upper band and "sell" if below lower band."""
+    period = getattr(config, "bb_period", 20)
+    std_mult = getattr(config, "bb_std_multiplier", 2.0)
+
+    rolling = df["close"].rolling(period)
+    mid = rolling.mean()
+    std = rolling.std()
+    upper = mid + std_mult * std
+    lower = mid - std_mult * std
+
+    if len(df) <= period:
+        return None
+
+    close_now = df["close"].iloc[-1]
+    upper_prev = upper.iloc[-2]
+    lower_prev = lower.iloc[-2]
+
+    if pd.notna(upper_prev) and close_now > upper_prev:
+        return "buy"
+    if pd.notna(lower_prev) and close_now < lower_prev:
+        return "sell"
+    return None

--- a/tests/test_bollinger_breakout.py
+++ b/tests/test_bollinger_breakout.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Add src directory to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from bot import Config, TraderBot, SymbolFetcher
+
+
+def make_df(closes):
+    timestamps = pd.date_range("2024-01-01", periods=len(closes), freq="min")
+    return pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": closes,
+            "high": closes,
+            "low": closes,
+            "close": closes,
+            "volume": [0] * len(closes),
+        }
+    )
+
+
+def test_bollinger_breakout(monkeypatch):
+    # prevent background thread/network activity
+    monkeypatch.setattr(SymbolFetcher, "start", lambda self: None)
+    monkeypatch.setattr(SymbolFetcher, "wait_until_ready", lambda self, timeout=None: None)
+
+    df_buy = make_df([100] * 20 + [105])
+    df_sell = make_df([100] * 20 + [95])
+
+    bot = TraderBot(Config(symbol="T-USD", strategy="bollinger_breakout"))
+    assert bot.generate_signal(df_buy) == "buy"
+    assert bot.generate_signal(df_sell) == "sell"


### PR DESCRIPTION
## Summary
- implement Bollinger Band breakout strategy that signals buys above the upper band and sells below the lower band
- expose strategy through `strategies` package and CLI `--strategy` flag
- test Bollinger breakout behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1de6682b0832ca382099df1723378